### PR TITLE
Fixes path for the Basic GPU example

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -209,7 +209,7 @@ $ ./build/demos/demo_ivfpq_indexing
 
 ``` shell
 $ make -C build demo_ivfpq_indexing_gpu
-$ ./build/demos/demo_ivfpq_indexing_gpu
+$ ./build/faiss/gpu/test/demo_ivfpq_indexing_gpu
 ```
 
 This produce the GPU code equivalent to the CPU `demo_ivfpq_indexing`. It also


### PR DESCRIPTION
In the install, the path to the Basic GPU example is incorrect.

This PR corrects it.